### PR TITLE
Make reloading page work with different paths

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -13,6 +13,7 @@ bambuMonitorClient.Connect(()=>
 {
   console.log("[App] BambuMonitorClient connected");
   bambuMonitorClient.GetState();
+  bambuMonitorClient.RequestJobHistory();
   bambuMonitorClient.RequestFullLog();
 });
 </script>

--- a/client/src/components/pages/HistoryPage.vue
+++ b/client/src/components/pages/HistoryPage.vue
@@ -9,11 +9,6 @@ if (bambuMonitorClient === undefined)
   throw new Error ("[HistoryPage] Setup: No BambuMonitorClient plugin found.");
 }
 
-onMounted(()=>
-{
-    bambuMonitorClient.RequestJobHistory();
-});
-
 function status(job : Job)
 {
     switch (job.State)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -122,8 +122,8 @@ app.get("/config.json", (request, response) =>
     }
   ))
 });
-app.use("/",               express.static(path.join(__dirname, wwwroot)));
 app.use("/projectArchive", express.static(path.join(__dirname, projectArchive)));
+app.use("/",               express.static(path.join(__dirname, wwwroot)));
 
 app.listen(webPort, () => {
   logger.Log(`[Web] Server is running at http://localhost:${webPort}`);


### PR DESCRIPTION
Unclear why placing the / route last achieves this but it appears to work.

Also, loading the history in App.vue makes sure that the api is connected, if done on mount the socket may not have been connected yet when reloading the page.